### PR TITLE
Support for non blocking mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,9 @@ Usage
 
 ``mqttwrapper.run_script`` handles the setup/maintenance of the MQTT connection
 and subscriptions to topics, and calls a callback function when messages are
-received.
+received. It can run in blocking mode where it will take care of the MQTT
+client handling or in non blocking mode where a new thread takes care this
+leaving your main thread free for other things.
 
 The simplest script looks something like this::
 
@@ -32,6 +34,14 @@ The simplest script looks something like this::
 
   def main():
       run_script(callback, broker="mqtt://127.0.0.1", topics=["my/awesome/topic1", "another/awesome/topic2"])
+
+or in non blocking mode:
+
+  def main():
+      run_script(callback, broker="mqtt://127.0.0.1", topics=["my/awesome/topic1", "another/awesome/topic2", blocking=False])
+      while True:
+          echo "Alive and kicking"
+          time.sleep(1)
 
 Any extra keyword arguments passed to ``run_script`` are passed back to the
 callback function when it's called::

--- a/mqttwrapper/paho_backend.py
+++ b/mqttwrapper/paho_backend.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import paho.mqtt.client as mqtt
+import threading
 
 log = logging.getLogger("mqttwrapper.paho_backend")
 
@@ -15,7 +16,10 @@ def on_message(client, userdata, msg):
     if msg.retain and userdata['ignore_retained']:
         log.debug("Ignoring retained message")
         return
-    replies = userdata['callback'](msg.topic, msg.payload, **userdata['kwargs'])
+    try:
+        replies = userdata['callback'](msg.topic, msg.payload, **userdata['kwargs'])
+    except Exception as e:
+        log.error("Callback caused exception", exc_info = True)
     log.debug("Callback completed.")
     if replies is not None:
         log.debug("Received %s replies", len(replies))
@@ -24,8 +28,10 @@ def on_message(client, userdata, msg):
             client.publish(topic, payload)
             log.debug("Published '%s' to %s", payload, topic)
 
+def mqtt_thread(client):
+    client.loop_forever()
 
-def run_script(callback, broker=None, topics=None, ignore_retained=False, **kwargs):
+def run_script(callback, broker=None, topics=None, ignore_retained=False, blocking=True, **kwargs):
     if not broker:
         broker = os.environ['MQTT_BROKER']
     if not topics:
@@ -42,4 +48,8 @@ def run_script(callback, broker=None, topics=None, ignore_retained=False, **kwar
     client.on_connect = on_connect
     client.on_message = on_message
     client.connect(broker.split("//")[1])
-    client.loop_forever()
+    if blocking:
+        client.loop_forever()
+    else:
+        t = threading.Thread(target=mqtt_thread, args=(client,), daemon=True)
+        t.start()


### PR DESCRIPTION
Support for non blocking mode in case one wants to use the main thread for other things. I use it to handle a Pygame application and have the MQTT stuff run in its own thread.

I also took the liberty of handling the naughty behaviour of the Paho MQTT library to silently eat exceptions in the user callback.